### PR TITLE
[FIX] 채팅 전송, 안 읽은 메시지수 수정

### DIFF
--- a/src/main/java/com/tt/Together_time/config/MongoConfig.java
+++ b/src/main/java/com/tt/Together_time/config/MongoConfig.java
@@ -1,0 +1,9 @@
+package com.tt.Together_time.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@Configuration
+@EnableMongoAuditing
+public class MongoConfig {
+}

--- a/src/main/java/com/tt/Together_time/config/WebSocketConfig.java
+++ b/src/main/java/com/tt/Together_time/config/WebSocketConfig.java
@@ -8,6 +8,8 @@ import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 
+import java.util.Map;
+
 @Slf4j
 @Configuration
 @EnableWebSocket
@@ -24,13 +26,12 @@ public class WebSocketConfig implements WebSocketConfigurer {
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         log.info("✅ WebSocket 핸들러 등록 시작");
+
         registry.addHandler(webSocketHandler, "/ws/online-status")
-                .setAllowedOriginPatterns("http://localhost:3000")
-                .withSockJS();
+                .setAllowedOriginPatterns("http://localhost:3000");
 
         registry.addHandler(chatWebSocketHandler, "/ws/chat")
-                .setAllowedOriginPatterns("*")
-                .withSockJS();
+                .setAllowedOriginPatterns("*");
         log.info("✅ WebSocket 핸들러 등록 완료: /ws/chat");
     }
 }

--- a/src/main/java/com/tt/Together_time/controller/ChatController.java
+++ b/src/main/java/com/tt/Together_time/controller/ChatController.java
@@ -1,20 +1,26 @@
 package com.tt.Together_time.controller;
 
 import com.tt.Together_time.domain.dto.ChatDto;
+import com.tt.Together_time.domain.mongodb.ChatDocument;
+import com.tt.Together_time.repository.ChatMongoRepository;
 import com.tt.Together_time.service.ChatService;
 import com.tt.Together_time.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/chat")
 @RequiredArgsConstructor
 public class ChatController {
     private final ChatService chatService;
     private final MemberService memberService;
+
+    private final ChatMongoRepository chatMongoRepository;
 
     @GetMapping
     public ResponseEntity<List<ChatDto>> getMessages(
@@ -26,12 +32,15 @@ public class ChatController {
         return ResponseEntity.ok(messages);
     }
     //안 읽은 메시지 개수
-    @GetMapping("/unread-count")
+    @GetMapping("/unread")
     public ResponseEntity<Long> getUnreadCount(
-            @RequestParam String projectId) {
+            @RequestParam Long projectId) {
         String loggedInMember = memberService.getUserEmail();
 
+        log.info("loggedInMember {}", loggedInMember);
+
         long count = chatService.getUnreadMessageCount(projectId, loggedInMember);
+        log.info("count {}", count);
         return ResponseEntity.ok(count);
     }
 }

--- a/src/main/java/com/tt/Together_time/domain/dto/ChatDto.java
+++ b/src/main/java/com/tt/Together_time/domain/dto/ChatDto.java
@@ -13,14 +13,14 @@ import java.time.LocalDateTime;
 public class ChatDto {
     private String content;
     private LocalDateTime createdAt;
-    private String sender;
-    private String projectId;
+    private Sender sender;
+    private Long projectId;
     private int unreadCount;
 
     public ChatDto(ChatDocument chatDocument) {
         this.content = chatDocument.getContent();
         this.createdAt = chatDocument.getCreatedAt();
-        this.sender = chatDocument.getSender().getNickname();
+        this.sender = chatDocument.getSender();
         this.projectId = chatDocument.getProjectId();
         this.unreadCount = chatDocument.getUnreadBy().size(); // 안 읽은 사람 수 계산
     }

--- a/src/main/java/com/tt/Together_time/domain/dto/Sender.java
+++ b/src/main/java/com/tt/Together_time/domain/dto/Sender.java
@@ -1,0 +1,11 @@
+package com.tt.Together_time.domain.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Sender {
+    private String nickname;
+    private String email;
+}

--- a/src/main/java/com/tt/Together_time/domain/mongodb/ChatDocument.java
+++ b/src/main/java/com/tt/Together_time/domain/mongodb/ChatDocument.java
@@ -1,10 +1,11 @@
 package com.tt.Together_time.domain.mongodb;
 
-import com.tt.Together_time.domain.rdb.Member;
+import com.tt.Together_time.domain.dto.Sender;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
@@ -20,8 +21,11 @@ public class ChatDocument {
     private String id;
 
     private String content;
+
+    @CreatedDate
     private LocalDateTime createdAt;
-    private Member sender;
-    private String projectId;
-    private List<String> unreadBy = new ArrayList<>();
+
+    private Sender sender;
+    private Long projectId;
+    private List<Sender> unreadBy = new ArrayList<>();
 }

--- a/src/main/java/com/tt/Together_time/repository/ChatMongoRepository.java
+++ b/src/main/java/com/tt/Together_time/repository/ChatMongoRepository.java
@@ -3,6 +3,7 @@ package com.tt.Together_time.repository;
 import com.tt.Together_time.domain.mongodb.ChatDocument;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 
@@ -10,9 +11,9 @@ public interface ChatMongoRepository extends MongoRepository<ChatDocument, Strin
 
     List<ChatDocument> findByProjectIdOrderByCreatedAtDesc(String projectId, Pageable pageable);
 
-    long countByProjectIdAndUnreadByContains(String projectId, String logged);
+    long countByProjectIdAndUnreadByEmail(Long projectId, String email);
 
-    List<ChatDocument> findByProjectIdAndUnreadByContains(String projectId, String logged);
+    List<ChatDocument> findByProjectIdAndUnreadByEmail(Long projectId, String email);
 
     void deleteByProjectId(Long projectId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+      time-to-live: 600000
     mongodb:
       uri: ${MONGODB_URL}
   jwt:


### PR DESCRIPTION
채팅 전송 - sender의 nickname만 저장하는 방식에서 읽음 처리 및 안 읽은 메시지 수 확인을 위해 Sender 클래스의 객체로 변경, 캐시 사용

안 읽은 메시지수 - Query 어노테이션 삭제 및 projectId 타입 변경(String to Long)